### PR TITLE
Starting to explore API decoupling (Signature clashes)

### DIFF
--- a/api.php
+++ b/api.php
@@ -162,6 +162,9 @@ function geoip_detect2_get_info_from_current_ip($locales = null, $options = arra
  * @since 2.0.0
  * @since 2.5.0 new parameter $options
  * @since 2.7.0 Parameter $options['source'] has been introduced
+ * @since 4.1.0 This does not return a Maxmind Reader anymore, as the plugin readers have been decoupled from the Maxmind Readers (API incompability). But the method names stay the same.
+ * 
+ * @return \YellowTree\GeoipDetect\DataSources\ReaderInterface $reader
  */
 function geoip_detect2_get_reader($locales = null, $options = array()) {
 	_geoip_maybe_disable_pagecache();

--- a/data-sources/abstract.php
+++ b/data-sources/abstract.php
@@ -84,11 +84,29 @@ class ExtraInformation extends \GeoIp2\Record\AbstractRecord {
 	protected $validAttributes = array('source', 'cached', 'error', 'original', 'flag', 'tel', 'countryIsoCode3', 'currencyCode');
 }
 
-interface ReaderInterface extends \GeoIp2\ProviderInterface {
+/**
+ * This interface is basically extending \GeoIp2\ProviderInterface ,
+ * but due to signature changes in the Maxmind lib, extending it would not be wise (as it breaks as soon as other plugins are using a different version of the Maxmind lib)
+ */
+interface ReaderInterface {
 	/**
      * Closes the database and returns the resources to the system.
      */
 	public function close();
+
+	/**
+     * @param string $ipAddress an IPv4 or IPv6 address to lookup
+     *
+     * @return \GeoIp2\Model\Country a Country model for the requested IP address
+     */
+    public function country($ipAddress);
+
+    /**
+     * @param string $ipAddress an IPv4 or IPv6 address to lookup
+     *
+     * @return \GeoIp2\Model\City a City model for the requested IP address
+     */
+	public function city($ipAddress);
 }
 	
 abstract class AbstractReader implements \YellowTree\GeoipDetect\DataSources\ReaderInterface {

--- a/data-sources/header.php
+++ b/data-sources/header.php
@@ -58,7 +58,7 @@ class HeaderReader extends \YellowTree\GeoipDetect\DataSources\AbstractReader {
 		
 		$r['traits']['ip_address'] = $ip;
 		
-		$record = new \GeoIp2\Model\City($r, array('en'));
+		$record = new \YellowTree\GeoipDetect\DataSources\City($r, array('en'));
 		
 		return $record;
 	}

--- a/data-sources/manual.php
+++ b/data-sources/manual.php
@@ -207,6 +207,7 @@ HTML;
 		$data_file = $this->maxmindGetFilename();
 		if ($data_file) {
 			try {
+				// ToDo this needs to be wrapped?
 				$reader = new \GeoIp2\Database\Reader ( $data_file, $locales );
 			} catch ( \Exception $e ) {
 				if (WP_DEBUG)

--- a/geoip-detect-lib.php
+++ b/geoip-detect-lib.php
@@ -75,7 +75,7 @@ function _geoip_detect2_process_options($options) {
  * @param array(string)				List of locale codes to use in name property
  * from most preferred to least preferred. (Default: Site language, en)
  * @param boolean					If locale filter should be skipped (default: No)
- * @return GeoIp2\Database\Reader 	The reader, ready to do its work. Don't forget to `close()` it afterwards. NULL if file not found (or other problems).
+ * @return \YellowTree\GeoipDetect\DataSources\ReaderInterface 	The reader, ready to do its work. Don't forget to `close()` it afterwards. NULL if file not found (or other problems).
  * NULL if initialization went wrong (e.g., File not found.)
  */
 function _geoip_detect2_get_reader($locales = null, $skipLocaleFilter = false, &$sourceId = '', $options = array()) {
@@ -211,7 +211,7 @@ function _geoip_detect2_get_record_from_reader($reader, $ip, &$error) {
 
 function _geoip_detect2_get_new_empty_record($ip = '') {
 	$data = array('traits' => array('ip_address' => $ip), 'is_empty' => true);
-	return new \GeoIp2\Model\City($data);
+	return new \YellowTree\GeoipDetect\DataSources\City($data);
 }
 
 function _geoip_detect2_record_enrich_data($record, $ip, $sourceId, $error) : array {


### PR DESCRIPTION
I don't want to extend Maxmind classes anymore (or as less as
possible/reasonable), instead wrapping them with my own types. 

* [ ] My readers should always return my City model
* [ ] This means, the Maxmind Reader class in manual.php needs to be wrapped
* [ ] Can the model stay extended?



Reason: PHP 7 Typing is helpful, but when different plugins use different versions of the Maxmind library, everything goes downhill.
See https://wordpress.org/support/topic/maxmind-lib-incompabilities-meta-ticket/