### PR TITLE
Static Lookup cache 

### DIFF
--- a/api.php
+++ b/api.php
@@ -132,7 +132,8 @@ function geoip_detect2_get_info_from_ip(string $ip, $locales = null, $options = 
  * @param array(string)		$locales	List of locale codes to use in name property
  * 										from most preferred to least preferred. (Default: Site language, en)
  * @param array				Property names with options.
- * 		@param boolean 		$skipCache		TRUE: Do not use cache for this request. (Default: FALSE)
+ * 		@param boolean 		$skipCache		TRUE: Do not use persistent cache for this request. (Default: FALSE)
+ * 		@param boolean		$skipLocalCache	TRUE: Do not use caching in memory (Default: FALSE)
  * 		@param string       $source         Change the source for this request only. (Valid values: 'auto', 'manual', 'precision', 'header', 'hostinfo')
  * 		@param float 		$timeout		Total transaction timeout in seconds (Precision+HostIP.info API only)
  * 		@param int			$connectTimeout Initial connection timeout in seconds (Precision API only)
@@ -142,9 +143,23 @@ function geoip_detect2_get_info_from_ip(string $ip, $locales = null, $options = 
  * @since 2.4.0 New parameter $skipCache
  * @since 2.5.0 Parameter $skipCache has been renamed to $options with 'skipCache' property
  * @since 2.7.0 Parameter $options['source'] has been introduced
+ * @since 4.3.0 The result of this function is cached for the duration of the PHP execution (except if you use skipLocalCache)
  */
 function geoip_detect2_get_info_from_current_ip($locales = null, $options = array()) {
-	return geoip_detect2_get_info_from_ip(geoip_detect2_get_client_ip(), $locales, $options);
+	static $cache = null;
+
+	if (empty($options['skipLocalCache'])) {
+		if (!is_null($cache)) {
+			return $cache;
+		}
+	}
+
+	$ret = geoip_detect2_get_info_from_ip(geoip_detect2_get_client_ip(), $locales, $options);
+	if (empty($options['skipLocalCache'])) {
+		$cache = $ret;
+	}
+
+	return $ret;
 }
 
 

--- a/api.php
+++ b/api.php
@@ -137,7 +137,7 @@ function geoip_detect2_get_info_from_ip(string $ip, $locales = null, $options = 
  * 		@param string       $source         Change the source for this request only. (Valid values: 'auto', 'manual', 'precision', 'header', 'hostinfo')
  * 		@param float 		$timeout		Total transaction timeout in seconds (Precision+HostIP.info API only)
  * 		@param int			$connectTimeout Initial connection timeout in seconds (Precision API only)
- * @return YellowTree\GeoipDetect\DataSources\City	GeoInformation.
+ * @return \YellowTree\GeoipDetect\DataSources\City	GeoInformation.
  *
  * @since 2.0.0
  * @since 2.4.0 New parameter $skipCache
@@ -146,11 +146,16 @@ function geoip_detect2_get_info_from_ip(string $ip, $locales = null, $options = 
  * @since 4.3.0 The result of this function is cached for the duration of the PHP execution (except if you use skipLocalCache)
  */
 function geoip_detect2_get_info_from_current_ip($locales = null, $options = array()) {
+	/** @var \YellowTree\GeoipDetect\DataSources\City  */
 	static $cache = null;
 
 	if (empty($options['skipLocalCache'])) {
 		if (!is_null($cache)) {
-			return $cache;
+			$locales = apply_filters('geoip_detect2_locales', $locales);
+			$data = $cache->jsonSerialize();
+			$data = apply_filters('geoip_detect2_record_data_after_cache', $data, $cache->traits->ipAddress);
+			$record = new \YellowTree\GeoipDetect\DataSources\City($data, $locales);
+			return $record;
 		}
 	}
 

--- a/js/frontend.js
+++ b/js/frontend.js
@@ -11,6 +11,7 @@ if (options.do_body_classes) {
 // Do all the shortcodes that are in the HTML. Even if shortcodes is not enabled globally, they might be enabled for a specific shortcode.
 do_shortcodes();
 
+
 // Extend window object 
 window.geoip_detect.get_info = get_info;
 

--- a/js/shortcodes/index.js
+++ b/js/shortcodes/index.js
@@ -5,6 +5,7 @@ import { do_shortcode_show_if } from "./show-if";
 
 
 export const do_shortcodes = async function do_shortcodes() {
+    // Before doing any of these, the DOM tree needs to be loaded
     await domReady;
 
     // These are called in parallel, as they are async functions

--- a/readme.txt
+++ b/readme.txt
@@ -165,6 +165,10 @@ If you use Maxmind "Automatic download" then you need to upgrade to this plugin 
 
 == Changelog ==
 
+= 4.3.0 =
+* NEW: Drastically improving performance if the the lookup is performed for the current IP more than once (e.g. because of shortcodes)
+* UI: Showing the time for the subsequent lookup on the Test Lookup page
+
 = 4.2.0 =
 * NEW: Show a warning on the options page when there are incompatibilities with other plugins that also use the Maxmind libraries.
 * FIX: Remove an incompatibility of the libraries with Toolset or other Laravel-based plugins


### PR DESCRIPTION
Drastically improving performance if the the lookup is performed for the current IP more than once (e.g. because of shortcodes)

* [x] Cache lookup result in a static variable
* [x] Expose the lookup time for a second lookup in the test backend